### PR TITLE
Fixed assert as per issue #6.

### DIFF
--- a/components/lora/lora.c
+++ b/components/lora/lora.c
@@ -362,7 +362,7 @@ lora_init(void)
       if(version == 0x12) break;
       vTaskDelay(2);
    }
-   assert(i < TIMEOUT_RESET);
+   assert(i <= TIMEOUT_RESET + 1); // at the end of the loop above, the max value i can reach is TIMEOUT_RESET + 1
 
    /*
     * Default configuration.


### PR DESCRIPTION
Fix for issue #6. Not a major bug though. An edge case where version register returns proper value in the last iteration of the loop might cause assert to fail.