### PR TITLE
Missing lora_initialized() function implemented. [RK, 2021.07.18]

### DIFF
--- a/components/lora/lora.c
+++ b/components/lora/lora.c
@@ -499,3 +499,38 @@ lora_dump_registers(void)
    printf("\n");
 }
 
+/**
+ * @brief   Check if SX127x LoRa radio module initialized properly
+ * @return
+ *  - 0: Init failed
+ *  - 1: Init was succesful
+ * @note    RK, 2021.07.18
+ */
+int lora_initialized(void)
+{
+    /*
+    * Check version, see datasheet
+    * https://cdn-shop.adafruit.com/product-files/3179/sx1276_77_78_79.pdf, page 92, 105
+    */
+    uint8_t version;
+    uint8_t i = 0;
+    while (i < TIMEOUT_RESET)
+    {
+        version = lora_read_reg(REG_VERSION);
+        if (version == 0x12)
+            break;
+        vTaskDelay(2);
+        i++;
+    }
+    if (i >= TIMEOUT_RESET)
+    {
+        return 0;
+    }
+
+    /*
+    * Switch to idle mode.
+    */
+    lora_idle();
+
+    return 1;
+}


### PR DESCRIPTION
Hi @bruabas,
I implemented the missing lora_initialized() function in order to be able to check whether the SX127x module initialization was successful or not.
Please check the code and in case you like it you can merge this PR.
Best regards,
Robert