### PR TITLE
Minor changes

### DIFF
--- a/components/lora/CMakeLists.txt
+++ b/components/lora/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "lora.c"
+                    INCLUDE_DIRS "./include")

--- a/components/lora/lora.c
+++ b/components/lora/lora.c
@@ -375,7 +375,7 @@ lora_init(void)
    lora_set_tx_power(17);
 
    lora_idle();
-   return 1;
+   return version;
 }
 
 /**


### PR DESCRIPTION
Init function now returns the device version.
Added CMakeLists.txt for ESP-IDF v4.4.2+ support.

Signed-off-by: Thiago H. Deicke <deicke@live.com>